### PR TITLE
postgresql (for SQLAlchemy)

### DIFF
--- a/mautrix_hangouts/example-config.yaml
+++ b/mautrix_hangouts/example-config.yaml
@@ -28,7 +28,7 @@ appservice:
     # Other DBMSes supported by SQLAlchemy may or may not work.
     # Format examples:
     #   SQLite:   sqlite:///filename.db
-    #   Postgres: postgres://username:password@hostname/dbname
+    #   Postgres: postgresql://username:password@hostname/dbname
     database: sqlite:///mautrix-hangouts.db
     # Optional extra arguments for SQLAlchemy's create_engine
     database_opts: {}


### PR DESCRIPTION
According to [this thread](https://stackoverflow.com/questions/62688256), the dialect name "postgres" was deprecated in SQLAlchemy 1.4 and "postgresql" should be used instead. [See docs](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg2)