### PR TITLE
Only change the data directory ownership on start.

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -2,7 +2,7 @@
 
 # Define functions.
 function fixperms {
-	chown -R $UID:$GID /data /opt/mautrix-googlechat
+	chown -R $UID:$GID /data
 }
 
 cd /opt/mautrix-googlechat


### PR DESCRIPTION
Not only is this significantly quicker, it's more secure that the user executing the bridge cannot modify the contents it's executing.