### PR TITLE
db: correctly quote `index` columns to allow sqlite support

### DIFF
--- a/mautrix_googlechat/db/message.py
+++ b/mautrix_googlechat/db/message.py
@@ -49,7 +49,7 @@ class Message:
 
     columns = (
         "mxid, mx_room, gcid, gc_chat, gc_receiver, gc_parent_id, "
-        "index, timestamp, msgtype, gc_sender"
+        "`index`, timestamp, msgtype, gc_sender"
     )
 
     @classmethod
@@ -64,7 +64,7 @@ class Message:
     ) -> Message | None:
         q = (
             f"SELECT {cls.columns} FROM message"
-            " WHERE gcid=$1 AND gc_chat=$2 AND gc_receiver=$3 AND index=$4"
+            " WHERE gcid=$1 AND gc_chat=$2 AND gc_receiver=$3 AND `index`=$4"
         )
         row = await cls.db.fetchrow(q, gcid, gc_chat, gc_receiver, index)
         return cls._from_row(row)
@@ -76,7 +76,7 @@ class Message:
         q = (
             f"SELECT {cls.columns} FROM message"
             " WHERE (gc_parent_id=$1 OR gcid=$1) AND gc_chat=$2 AND gc_receiver=$3"
-            " ORDER BY timestamp DESC, index DESC LIMIT 1"
+            " ORDER BY timestamp DESC, `index` DESC LIMIT 1"
         )
         row = await cls.db.fetchrow(q, gc_parent_id, gc_chat, gc_receiver)
         return cls._from_row(row)
@@ -107,7 +107,7 @@ class Message:
         q = (
             f"SELECT {cls.columns} FROM message"
             " WHERE gc_chat=$1 AND gc_receiver=$2 AND timestamp<=$3"
-            " ORDER BY timestamp DESC, index DESC LIMIT 1"
+            " ORDER BY timestamp DESC, `index` DESC LIMIT 1"
         )
         row = await cls.db.fetchrow(q, gc_chat, gc_receiver, timestamp)
         return cls._from_row(row)
@@ -115,7 +115,7 @@ class Message:
     async def insert(self) -> None:
         q = (
             "INSERT INTO message (mxid, mx_room, gcid, gc_chat, gc_receiver, gc_parent_id, "
-            "                     index, timestamp, msgtype, gc_sender) "
+            "                     `index`, timestamp, msgtype, gc_sender) "
             "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"
         )
         await self.db.execute(
@@ -133,5 +133,5 @@ class Message:
         )
 
     async def delete(self) -> None:
-        q = "DELETE FROM message WHERE gcid=$1 AND gc_receiver=$2 AND index=$3"
+        q = "DELETE FROM message WHERE gcid=$1 AND gc_receiver=$2 AND `index`=$3"
         await self.db.execute(q, self.gcid, self.gc_receiver, self.index)

--- a/mautrix_googlechat/db/message.py
+++ b/mautrix_googlechat/db/message.py
@@ -49,7 +49,7 @@ class Message:
 
     columns = (
         "mxid, mx_room, gcid, gc_chat, gc_receiver, gc_parent_id, "
-        "`index`, timestamp, msgtype, gc_sender"
+        '"index", timestamp, msgtype, gc_sender'
     )
 
     @classmethod
@@ -64,7 +64,7 @@ class Message:
     ) -> Message | None:
         q = (
             f"SELECT {cls.columns} FROM message"
-            " WHERE gcid=$1 AND gc_chat=$2 AND gc_receiver=$3 AND `index`=$4"
+            ' WHERE gcid=$1 AND gc_chat=$2 AND gc_receiver=$3 AND "index"=$4'
         )
         row = await cls.db.fetchrow(q, gcid, gc_chat, gc_receiver, index)
         return cls._from_row(row)
@@ -76,7 +76,7 @@ class Message:
         q = (
             f"SELECT {cls.columns} FROM message"
             " WHERE (gc_parent_id=$1 OR gcid=$1) AND gc_chat=$2 AND gc_receiver=$3"
-            " ORDER BY timestamp DESC, `index` DESC LIMIT 1"
+            ' ORDER BY timestamp DESC, "index" DESC LIMIT 1'
         )
         row = await cls.db.fetchrow(q, gc_parent_id, gc_chat, gc_receiver)
         return cls._from_row(row)
@@ -107,7 +107,7 @@ class Message:
         q = (
             f"SELECT {cls.columns} FROM message"
             " WHERE gc_chat=$1 AND gc_receiver=$2 AND timestamp<=$3"
-            " ORDER BY timestamp DESC, `index` DESC LIMIT 1"
+            ' ORDER BY timestamp DESC, "index" DESC LIMIT 1'
         )
         row = await cls.db.fetchrow(q, gc_chat, gc_receiver, timestamp)
         return cls._from_row(row)
@@ -115,7 +115,7 @@ class Message:
     async def insert(self) -> None:
         q = (
             "INSERT INTO message (mxid, mx_room, gcid, gc_chat, gc_receiver, gc_parent_id, "
-            "                     `index`, timestamp, msgtype, gc_sender) "
+            '                     "index", timestamp, msgtype, gc_sender) '
             "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"
         )
         await self.db.execute(
@@ -133,5 +133,5 @@ class Message:
         )
 
     async def delete(self) -> None:
-        q = "DELETE FROM message WHERE gcid=$1 AND gc_receiver=$2 AND `index`=$3"
+        q = 'DELETE FROM message WHERE gcid=$1 AND gc_receiver=$2 AND "index"=$3'
         await self.db.execute(q, self.gcid, self.gc_receiver, self.index)

--- a/mautrix_googlechat/db/upgrade/v01_initial_revision.py
+++ b/mautrix_googlechat/db/upgrade/v01_initial_revision.py
@@ -67,9 +67,9 @@ async def upgrade_v1(conn: Connection) -> None:
             gc_chat      TEXT NOT NULL,
             gc_receiver  TEXT,
             gc_parent_id TEXT,
-            `index`        SMALLINT NOT NULL,
+            "index"        SMALLINT NOT NULL,
             timestamp    BIGINT   NOT NULL,
-            PRIMARY KEY (gcid, gc_chat, gc_receiver, `index`),
+            PRIMARY KEY (gcid, gc_chat, gc_receiver, "index"),
             FOREIGN KEY (gc_chat, gc_receiver) REFERENCES portal(gcid, gc_receiver)
                 ON UPDATE CASCADE ON DELETE CASCADE,
             UNIQUE (mxid, mx_room)

--- a/mautrix_googlechat/db/upgrade/v01_initial_revision.py
+++ b/mautrix_googlechat/db/upgrade/v01_initial_revision.py
@@ -67,9 +67,9 @@ async def upgrade_v1(conn: Connection) -> None:
             gc_chat      TEXT NOT NULL,
             gc_receiver  TEXT,
             gc_parent_id TEXT,
-            index        SMALLINT NOT NULL,
+            `index`        SMALLINT NOT NULL,
             timestamp    BIGINT   NOT NULL,
-            PRIMARY KEY (gcid, gc_chat, gc_receiver, index),
+            PRIMARY KEY (gcid, gc_chat, gc_receiver, `index`),
             FOREIGN KEY (gc_chat, gc_receiver) REFERENCES portal(gcid, gc_receiver)
                 ON UPDATE CASCADE ON DELETE CASCADE,
             UNIQUE (mxid, mx_room)

--- a/mautrix_googlechat/db/upgrade/v02_reactions.py
+++ b/mautrix_googlechat/db/upgrade/v02_reactions.py
@@ -25,7 +25,7 @@ async def upgrade_v2(conn: Connection, dialect: str) -> None:
         await conn.execute(
             "ALTER TABLE message"
             "  DROP CONSTRAINT message_pkey,"
-            "  ADD PRIMARY KEY (gcid, gc_chat, gc_receiver, `index`)"
+            '  ADD PRIMARY KEY (gcid, gc_chat, gc_receiver, "index")'
         )
     await conn.execute("ALTER TABLE message ADD COLUMN msgtype TEXT")
     await conn.execute("ALTER TABLE message ADD COLUMN gc_sender TEXT")
@@ -45,7 +45,7 @@ async def upgrade_v2(conn: Connection, dialect: str) -> None:
                 REFERENCES portal(gcid, gc_receiver)
                 ON UPDATE CASCADE ON DELETE CASCADE,
             FOREIGN KEY (gc_msgid, gc_chat, gc_receiver, _index)
-                REFERENCES message(gcid, gc_chat, gc_receiver, `index`)
+                REFERENCES message(gcid, gc_chat, gc_receiver, "index")
                 ON UPDATE CASCADE ON DELETE CASCADE,
             UNIQUE (mxid, mx_room)
         )"""

--- a/mautrix_googlechat/db/upgrade/v02_reactions.py
+++ b/mautrix_googlechat/db/upgrade/v02_reactions.py
@@ -25,7 +25,7 @@ async def upgrade_v2(conn: Connection, dialect: str) -> None:
         await conn.execute(
             "ALTER TABLE message"
             "  DROP CONSTRAINT message_pkey,"
-            "  ADD PRIMARY KEY (gcid, gc_chat, gc_receiver, index)"
+            "  ADD PRIMARY KEY (gcid, gc_chat, gc_receiver, `index`)"
         )
     await conn.execute("ALTER TABLE message ADD COLUMN msgtype TEXT")
     await conn.execute("ALTER TABLE message ADD COLUMN gc_sender TEXT")
@@ -45,7 +45,7 @@ async def upgrade_v2(conn: Connection, dialect: str) -> None:
                 REFERENCES portal(gcid, gc_receiver)
                 ON UPDATE CASCADE ON DELETE CASCADE,
             FOREIGN KEY (gc_msgid, gc_chat, gc_receiver, _index)
-                REFERENCES message(gcid, gc_chat, gc_receiver, index)
+                REFERENCES message(gcid, gc_chat, gc_receiver, `index`)
                 ON UPDATE CASCADE ON DELETE CASCADE,
             UNIQUE (mxid, mx_room)
         )"""


### PR DESCRIPTION
Yes, postgres is probably required for larger installations but I've
been successfully using the bridge for months with this patch applied,
so I figured I should send it upstream. As far as I know it shouldn't
hurt anything on other SQL engines, but I'm far from an expert.