### PR TITLE
Add main entry point to `console_scripts`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,11 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
+    entry_points={
+        'console_scripts': [
+            'mautrix-googlechat=mautrix_googlechat.__main__:main',
+        ]
+    },
     package_data={"mautrix_googlechat": [
         "web/static/*.png", "web/static/*.css", "web/static/*.html", "web/static/*.js",
         "example-config.yaml"


### PR DESCRIPTION
This just sets up `/bin/mautrix-googlechat` in some package managers so that there's actually a binary installed for the user to run.