### PR TITLE
fix: fall back to m.mentions for USER_MENTION annotations

### DIFF
--- a/mautrix_googlechat/formatter/from_matrix/__init__.py
+++ b/mautrix_googlechat/formatter/from_matrix/__init__.py
@@ -16,12 +16,64 @@
 from __future__ import annotations
 
 import html
+import logging
 
 from maugclib import googlechat_pb2 as googlechat
-from mautrix.types import Format, TextMessageEventContent
+from mautrix.types import Format, TextMessageEventContent, UserID
 
+from ... import puppet as pu
 from ..util import FormatError, add_surrogate, del_surrogate
+from .gc_message import GCEntity, GCEntityType
 from .parser import MX_ROOM_MENTION, parse_html
+
+log = logging.getLogger("mau.fmt.matrix")
+
+
+async def _annotations_from_m_mentions(
+    body: str,
+    mentions: dict,
+) -> list[googlechat.Annotation] | None:
+    """Build USER_MENTION annotations from MSC3952 m.mentions when formatted_body is absent."""
+    user_ids = mentions.get("user_ids")
+    if not user_ids:
+        return None
+    annotations = []
+    for mxid in user_ids:
+        gcid = pu.Puppet.get_id_from_mxid(UserID(mxid))
+        if not gcid:
+            continue
+        puppet = await pu.Puppet.get_by_gcid(gcid, create=False)
+        display_name = puppet.name if puppet else None
+        # Find the mention text in the body. Clients typically render as @DisplayName.
+        offset = -1
+        if display_name:
+            mention_text = f"@{display_name}"
+            offset = body.find(mention_text)
+            if offset == -1:
+                # Try without @ prefix in case the body has a different format
+                offset = body.find(display_name)
+        if offset == -1:
+            # Display name not found in body — skip this mention rather than
+            # inject an annotation with wrong offsets.
+            log.debug(
+                "Skipping m.mentions entry %s: display name %r not found in body",
+                mxid,
+                display_name,
+            )
+            continue
+        length = (
+            len(mention_text)
+            if display_name and body[offset:].startswith(f"@{display_name}")
+            else len(display_name or "")
+        )
+        entity = GCEntity(
+            type=GCEntityType.USER_MENTION,
+            offset=offset,
+            length=length,
+            extra_info={"user_id": gcid, "displayname": display_name},
+        )
+        annotations.append(entity.internal)
+    return annotations or None
 
 
 async def matrix_to_googlechat(
@@ -31,6 +83,11 @@ async def matrix_to_googlechat(
         if MX_ROOM_MENTION in content.body:
             content.formatted_body = html.escape(content.body)
         else:
+            # No HTML — fall back to m.mentions (MSC3952) for mention annotations.
+            mentions = content.get("m.mentions", {})
+            if mentions:
+                annotations = await _annotations_from_m_mentions(content.body, mentions)
+                return content.body, annotations
             return content.body, None
     try:
         text, entities = await parse_html(add_surrogate(content.formatted_body))


### PR DESCRIPTION
## Problem

When a Matrix client sends a message with `m.mentions` (MSC3952) but **no `formatted_body`**, the bridge drops all mention annotations. Google Chat receives the message as plain text with no `USER_MENTION` — the mentioned user gets no notification.

This happens because the bridge only extracts mentions from HTML `<a href="matrix.to">` pills in `formatted_body`. When `format != HTML`, it returns `(body, None)`.

The Beeper Desktop client hits this path because the Google Chat bridge does not report `FormattingFeature.UserLink` in room capabilities, causing the client to render mentions as `<span>` instead of `<a>`, which produces identical plain text for `body` and `formattedBody`, so `formatted_body` is omitted from the event.

## Fix

When `formatted_body` is absent, check for `m.mentions.user_ids` in the event content. For each mentioned MXID:

1. Resolve to Google Chat ID via `Puppet.get_id_from_mxid`
2. Look up puppet display name via `Puppet.get_by_gcid`
3. Find `@DisplayName` offset in the plain `body` text
4. Construct `USER_MENTION` annotation using existing `GCEntity` machinery

Gracefully skips unresolvable MXIDs, missing puppets, and display names not found in the body.

**Fallback-only path** — the existing HTML pill parsing is completely untouched.

## Related

- [DESK-26003](https://linear.app/beeper/issue/DESK-26003)